### PR TITLE
DevComDC-100: do not allow notifications number on screen grow more than fixed amount

### DIFF
--- a/scripts/app/application.js
+++ b/scripts/app/application.js
@@ -8,6 +8,19 @@ _.extend(app, {
     Views: {},
     Regions: {},
     User: null,
+    defaultConfig: {
+        deviceNotificationsNum: 100 // notifications per page
+    },
+    getConfig: function(option) {
+        var retval = null;
+        if (this.defaultConfig[option]) {
+            retval = this.defaultConfig[option];
+        }
+        if (this.config[option]) {
+            retval = this.config[option];
+        }
+        return retval;
+    },
     // override addRegion function to attach new regions
     addRegions: function (regions) {
         var regionValue, regionObj, region;

--- a/scripts/models/Notification.js
+++ b/scripts/models/Notification.js
@@ -42,7 +42,7 @@ app.Models.NotificationsCollection = Backbone.AuthCollection.extend({
         }
     },
     url: function () {
-        return app.restEndpoint + '/device/' + this.device.get("id") + "/notification?take=100&sortOrder=DESC";
+        return app.restEndpoint + '/device/' + this.device.get("id") + "/notification?take=" + app.getConfig('deviceNotificationsNum') + "&sortOrder=DESC";
     },
     parse: function (resp, xhr) {
         // reverse items order back to ascending
@@ -70,6 +70,11 @@ app.Models.NotificationsCollection = Backbone.AuthCollection.extend({
                 _.each(data, function (incomingNotification) {
                     that.add(new app.Models.Notification(incomingNotification, { device: that.device }));
                 });
+                // trim excess records
+                while (that.length > app.getConfig('deviceNotificationsNum')) {
+                    that.remove(that.models[0]);
+                    console.log('removed old record from collection to fit the limit')
+                }
             },
             complete: function () {
                 if (that.deleted == false)

--- a/scripts/views/Notifications.js
+++ b/scripts/views/Notifications.js
@@ -125,7 +125,7 @@ app.Views.Notifications = Backbone.Marionette.CompositeView.extend({
             that.timeFiltersView.$el.hide();
         });
 
-        if (this.collection.length >= 100) {
+        if (this.collection.length >= app.getConfig('deviceNotificationsNum')) {
             that.$el.find(".max-rows-number-reached").show();
         }
         else {


### PR DESCRIPTION
When new notification items arrive via polling channel the model adds new items and then the small check is appended that removes old records one by one until requested limit of visible notifications (100) not reached.
Misc:
Introduced an app.defaultConfig object and app.getConfig() method to get config properties. Default number of notifications per page is set to be 100.
Other parts of the code that were using this magic number now query app.getConfig('deviceNotificationsNum') for the value.
The default value can be altered by specifying new value in app.config object
