### PR TITLE
do not allow notifications number on screen grow more than fixed amount

### DIFF
--- a/scripts/app/application.js
+++ b/scripts/app/application.js
@@ -8,6 +8,19 @@ _.extend(app, {
     Views: {},
     Regions: {},
     User: null,
+    defaultConfig: {
+        deviceNotificationsNum: 100 // notifications per page
+    },
+    getConfig: function(option) {
+        var retval = null;
+        if (this.defaultConfig[option]) {
+            retval = this.defaultConfig[option];
+        }
+        if (this.config[option]) {
+            retval = this.config[option];
+        }
+        return retval;
+    },
     // override addRegion function to attach new regions
     addRegions: function (regions) {
         var regionValue, regionObj, region;

--- a/scripts/app/application.js
+++ b/scripts/app/application.js
@@ -8,19 +8,6 @@ _.extend(app, {
     Views: {},
     Regions: {},
     User: null,
-    defaultConfig: {
-        deviceNotificationsNum: 100 // notifications per page
-    },
-    getConfig: function(option) {
-        var retval = null;
-        if (this.defaultConfig[option]) {
-            retval = this.defaultConfig[option];
-        }
-        if (this.config[option]) {
-            retval = this.config[option];
-        }
-        return retval;
-    },
     // override addRegion function to attach new regions
     addRegions: function (regions) {
         var regionValue, regionObj, region;
@@ -105,29 +92,35 @@ _.extend(app, {
 });
 
 app.bind("initialize:before", function (options) {
-    app.restEndpoint = "";
+    var defaultConfig = {
+        restEndpoint: "", // should be overriden in config.js
+        rootUrl: "", //
+        pushState: false, // don't use push state, use hash route instead
+        deviceNotificationsNum: 100 // notifications per page
+    };
+
     if (_.isObject(options)) {
-        if (_.has(options, "rootUrl")) {
-            app.rootUrl = options.rootUrl;
-        }
         if (_.has(options, "restEndpoint")) {
             var val = options.restEndpoint;
-            if (val.length != 0 && (val.lastIndexOf("/") + 1) == val.length)
+            if (val.length != 0 && (val.lastIndexOf("/") + 1) == val.length) {
                 val = val.substr(0, val.length - 1);
+            }
 
-            app.restEndpoint = val;
-
-            var oauthConfig = new app.Models.OAuthConfig().get('providers');
-            app.googleConfig = oauthConfig.filter(function(element) {return 'google' === element.name})[0];
-            app.facebookConfig = oauthConfig.filter(function(element) {return 'facebook' === element.name})[0];
-            app.githubConfig = oauthConfig.filter(function(element) {return 'github' === element.name})[0];
+            options.restEndpoint = val;
         }
     }
+    // merge default options and app.config, store as app.config
+    app.config = _.extend(defaultConfig, options);
+
+    var oauthConfig = new app.Models.OAuthConfig().get('providers');
+    app.config.googleConfig = oauthConfig.filter(function(element) {return 'google' === element.name})[0];
+    app.config.facebookConfig = oauthConfig.filter(function(element) {return 'facebook' === element.name})[0];
+    app.config.githubConfig = oauthConfig.filter(function(element) {return 'github' === element.name})[0];
 });
 
 app.bind("initialize:after", function (options) {
     app.User = new app.Models.User();
-    var params = { root: app.rootUrl };
+    var params = { root: app.config.rootUrl };
 
     if (_.isObject(options)) {
         if (_.has(options, "pushState")) {

--- a/scripts/app/oauth2-app.js
+++ b/scripts/app/oauth2-app.js
@@ -67,25 +67,30 @@ _.extend(app, {
 });
 
 app.bind("initialize:before", function (options) {
-    app.restEndpoint = "";
+    var defaultConfig = {
+        restEndpoint: "", // should be overriden in config.js
+        rootUrl: "", //
+        pushState: false, // don't use push state, use hash route instead
+        deviceNotificationsNum: 100 // notifications per page
+    };
     if (_.isObject(options)) {
-        if (_.has(options, "rootUrl")) {
-            app.rootUrl = options.rootUrl;
-        }
         if (_.has(options, "restEndpoint")) {
             var val = options.restEndpoint;
             if (val.length != 0 && (val.lastIndexOf("/") + 1) == val.length)
                 val = val.substr(0, val.length - 1);
 
-            app.restEndpoint = val;
+            options.restEndpoint = val;
         }
     }
+    // merge default options and app.config, store as app.config
+    app.config = _.extend(defaultConfig, options);
+
     app.User = new app.Models.User();
     app.OAuth2 = new app.Models.OAuth2();
 });
 
 app.bind("initialize:after", function (options) {
-    var params = { root: app.rootUrl };
+    var params = { root: app.config.rootUrl };
 
     if (_.isObject(options)) {
         if (_.has(options, "pushState")) {

--- a/scripts/libs/backbone.marionette.template.loading.js
+++ b/scripts/libs/backbone.marionette.template.loading.js
@@ -1,5 +1,5 @@
 ﻿Backbone.Marionette.TemplateCache.prototype.loadTemplate = function (templateId, callback) {
-    var url = app.rootUrl + "/scripts/templates/" + templateId + ".html";
+    var url = app.config.rootUrl + "/scripts/templates/" + templateId + ".html";
 
     var templateHtml = "";
     $.ajax({ url: url, async: false, success: function (data) {

--- a/scripts/models/AccessKey.js
+++ b/scripts/models/AccessKey.js
@@ -27,7 +27,7 @@ app.Models.AccessKeysCollection = Backbone.AuthCollection.extend({
         }
     },
     url: function () {
-        return app.restEndpoint + "/user/" + (this.userId != null ? this.userId : "current") + "/accesskey";
+        return app.config.restEndpoint + "/user/" + (this.userId != null ? this.userId : "current") + "/accesskey";
     },
     model: app.Models.AccessKey,
     comparator: function (network) {

--- a/scripts/models/AccessToken.js
+++ b/scripts/models/AccessToken.js
@@ -1,6 +1,6 @@
 app.Models.AccessToken = Backbone.Model.extend({
     url: function() {
-        return app.restEndpoint + '/auth/accesskey';
+        return app.config.restEndpoint + '/auth/accesskey';
     },
     initialize: function (params) {
         sessionStorage.loginMethod = params.providerName;
@@ -16,7 +16,7 @@ app.Models.AccessToken = Backbone.Model.extend({
             async: false,
 
             success: function (response) {
-                var appUrl =  app.f.prepareAbsolutePath(app.rootUrl);
+                var appUrl =  app.f.prepareAbsolutePath(app.config.rootUrl);
                 sessionStorage.deviceHiveToken=response.get('key');
                 sessionStorage.lastActivity=(new Date()).valueOf();
                 delete sessionStorage.authenticationError;

--- a/scripts/models/Command.js
+++ b/scripts/models/Command.js
@@ -18,7 +18,7 @@
         }
     },
     urlRoot: function () {
-        return app.restEndpoint + '/device/' + this.device.get("id") + "/command";
+        return app.config.restEndpoint + '/device/' + this.device.get("id") + "/command";
     },
     copyIt: function () {
         var fields = {
@@ -53,7 +53,7 @@ app.Models.CommandsCollection = Backbone.AuthCollection.extend({
 
     },
     url: function () {
-        return app.restEndpoint + '/device/' + this.device.get("id") + "/command?take=100&sortOrder=DESC";
+        return app.config.restEndpoint + '/device/' + this.device.get("id") + "/command?take=100&sortOrder=DESC";
     },
     parse: function (resp, xhr) {
         // reverse items order back to ascending
@@ -67,7 +67,7 @@ app.Models.CommandsCollection = Backbone.AuthCollection.extend({
     },
     //start polling updates from the server and add them to collection
     pollUpdates: function () {
-        var pollUrl = app.restEndpoint + "/device/" + this.device.get("id") + "/command/poll";
+        var pollUrl = app.config.restEndpoint + "/device/" + this.device.get("id") + "/command/poll";
         var that = this;
         this.deleted = false;
 

--- a/scripts/models/Device.js
+++ b/scripts/models/Device.js
@@ -1,6 +1,6 @@
 ﻿app.Models.Device = Backbone.AuthModel.extend({
     urlRoot: function () {
-         return app.restEndpoint + "/device";
+         return app.config.restEndpoint + "/device";
      },
      setStrData: function (value) {
          try {
@@ -15,7 +15,7 @@
 
 app.Models.DevicesCollection = Backbone.AuthCollection.extend({
     url: function () {
-         return app.restEndpoint + "/device";
+         return app.config.restEndpoint + "/device";
     },
     model: app.Models.Device,
     comparator: function (device) {

--- a/scripts/models/DeviceClass.js
+++ b/scripts/models/DeviceClass.js
@@ -1,6 +1,6 @@
 ﻿app.Models.DeviceClass = Backbone.AuthModel.extend({
     urlRoot: function () {
-        return app.restEndpoint + "/device/class";
+        return app.config.restEndpoint + "/device/class";
     },
     defaults: { equimpent: [], isPermanent: false, version: 1, offlineTimeout: null },
     getEquipments: function (success, error) {
@@ -50,7 +50,7 @@
 
 app.Models.DeviceClassesCollection = Backbone.AuthCollection.extend({
     url: function () {
-        return app.restEndpoint + "/device/class";
+        return app.config.restEndpoint + "/device/class";
     },
     model: app.Models.DeviceClass,
     comparator: function (dclass) {

--- a/scripts/models/DeviceEquipment.js
+++ b/scripts/models/DeviceEquipment.js
@@ -14,7 +14,7 @@
         }
     },
     urlRoot: function () {
-        return app.restEndpoint + '/device/' + this.device.get("id") + "/equipment";
+        return app.config.restEndpoint + '/device/' + this.device.get("id") + "/equipment";
     }
 });
 
@@ -32,7 +32,7 @@ app.Models.DeviceEquipmentsCollection = Backbone.AuthCollection.extend({
         }
     },
     url: function () {
-        return app.restEndpoint + '/device/' + this.device.get("id") + "/equipment";
+        return app.config.restEndpoint + '/device/' + this.device.get("id") + "/equipment";
     },
     //override fetch to merge equipment description with equipment states
     fetch: function (options) {

--- a/scripts/models/Equipment.js
+++ b/scripts/models/Equipment.js
@@ -13,7 +13,7 @@
         }
     },
     urlRoot: function () {
-        return app.restEndpoint + '/device/class/' + this.deviceClass.get("id") + "/equipment";
+        return app.config.restEndpoint + '/device/class/' + this.deviceClass.get("id") + "/equipment";
     },
     setStrData: function (value) {
         try {
@@ -39,7 +39,7 @@ app.Models.EquipmentsCollection = Backbone.AuthCollection.extend({
         }
     },
     url: function () {
-        return app.restEndpoint + '/device/class/' + this.deviceClass.get("id") + "/equipment";
+        return app.config.restEndpoint + '/device/class/' + this.deviceClass.get("id") + "/equipment";
     },
     //override fetch to make got the list of equipment throught the DeviceClass endpoint
     fetch: function (options) {

--- a/scripts/models/Grant.js
+++ b/scripts/models/Grant.js
@@ -1,12 +1,12 @@
 ﻿app.Models.Grant = Backbone.AuthModel.extend({
     urlRoot: function () {
-         return app.restEndpoint + "/user/current/oauth/grant";
+         return app.config.restEndpoint + "/user/current/oauth/grant";
      }
 });
 
 app.Models.GrantsCollection = Backbone.AuthCollection.extend({
     url: function () {
-         return app.restEndpoint + "/user/current/oauth/grant";
+         return app.config.restEndpoint + "/user/current/oauth/grant";
     },
     model: app.Models.Grant,
 });

--- a/scripts/models/Network.js
+++ b/scripts/models/Network.js
@@ -1,10 +1,10 @@
 ﻿app.Models.Network = Backbone.AuthModel.extend({
-    urlRoot: function () { return app.restEndpoint + "/network"; },
+    urlRoot: function () { return app.config.restEndpoint + "/network"; },
     defaults: { devices: [], key: "" }
 });
 
 app.Models.NetworksCollection = Backbone.AuthCollection.extend({
-    url: function () { return app.restEndpoint + "/network"; },
+    url: function () { return app.config.restEndpoint + "/network"; },
     model: app.Models.Network,
     comparator: function (network) {
         var name = network.get("name");

--- a/scripts/models/Notification.js
+++ b/scripts/models/Notification.js
@@ -17,7 +17,7 @@
         }
     },
     urlRoot: function () {
-        return app.restEndpoint + '/device/' + this.device.get("id") + "/notification";
+        return app.config.restEndpoint + '/device/' + this.device.get("id") + "/notification";
     },
     copyIt: function () {
         var fields = {
@@ -42,7 +42,7 @@ app.Models.NotificationsCollection = Backbone.AuthCollection.extend({
         }
     },
     url: function () {
-        return app.restEndpoint + '/device/' + this.device.get("id") + "/notification?take=" + app.getConfig('deviceNotificationsNum') + "&sortOrder=DESC";
+        return app.config.restEndpoint + '/device/' + this.device.get("id") + "/notification?take=" + app.config.deviceNotificationsNum + "&sortOrder=DESC";
     },
     parse: function (resp, xhr) {
         // reverse items order back to ascending
@@ -55,7 +55,7 @@ app.Models.NotificationsCollection = Backbone.AuthCollection.extend({
         }
     },
     pollUpdates: function () {
-        var pollUrl = app.restEndpoint + "/device/" + this.device.get("id") + "/notification/poll";
+        var pollUrl = app.config.restEndpoint + "/device/" + this.device.get("id") + "/notification/poll";
         var that = this;
         this.deleted = false;
 
@@ -71,7 +71,7 @@ app.Models.NotificationsCollection = Backbone.AuthCollection.extend({
                     that.add(new app.Models.Notification(incomingNotification, { device: that.device }));
                 });
                 // trim excess records
-                while (that.length > app.getConfig('deviceNotificationsNum')) {
+                while (that.length > app.config.deviceNotificationsNum) {
                     that.remove(that.models[0]);
                     console.log('removed old record from collection to fit the limit')
                 }

--- a/scripts/models/Notification.js
+++ b/scripts/models/Notification.js
@@ -42,7 +42,7 @@ app.Models.NotificationsCollection = Backbone.AuthCollection.extend({
         }
     },
     url: function () {
-        return app.restEndpoint + '/device/' + this.device.get("id") + "/notification?take=100&sortOrder=DESC";
+        return app.restEndpoint + '/device/' + this.device.get("id") + "/notification?take=" + app.getConfig('deviceNotificationsNum') + "&sortOrder=DESC";
     },
     parse: function (resp, xhr) {
         // reverse items order back to ascending
@@ -70,6 +70,11 @@ app.Models.NotificationsCollection = Backbone.AuthCollection.extend({
                 _.each(data, function (incomingNotification) {
                     that.add(new app.Models.Notification(incomingNotification, { device: that.device }));
                 });
+                // trim excess records
+                while (that.length > app.getConfig('deviceNotificationsNum')) {
+                    that.remove(that.models[0]);
+                    console.log('removed old record from collection to fit the limit')
+                }
             },
             complete: function () {
                 if (that.deleted == false)

--- a/scripts/models/OAuth2.js
+++ b/scripts/models/OAuth2.js
@@ -59,7 +59,7 @@ app.Models.OAuth2 = Backbone.Model.extend({
         cache: false,
     },
     getUrl: function(part) {
-        return app.restEndpoint+part;
+        return app.config.restEndpoint+part;
     },
     checkUser: function() {
         if (app.hasCredentials()) {
@@ -82,7 +82,7 @@ app.Models.OAuth2 = Backbone.Model.extend({
                     self.checkUser();
                 }
             } else {
-                app.vent.trigger('notification', app.Enums.NotificationType.Error, resp[0], 'No OAuth2 client with id '+self.get('client_id'));
+                app.vent.trigger('notification', app.Enums.NotificationType.Error, resp, 'No OAuth2 client with id '+self.get('client_id'));
             }
         };
         options.error = function(resp) {

--- a/scripts/models/OAuth2AccessToken.js
+++ b/scripts/models/OAuth2AccessToken.js
@@ -1,6 +1,6 @@
 app.Models.OAuth2AccessToken = Backbone.Model.extend({
     url: function() {
-        return app.restEndpoint + '/auth/accesskey';
+        return app.config.restEndpoint + '/auth/accesskey';
     },
     initialize: function (params) {
         sessionStorage.loginMethod = params.providerName;

--- a/scripts/models/OAuthClient.js
+++ b/scripts/models/OAuthClient.js
@@ -1,6 +1,6 @@
 app.Models.OAuthClient = Backbone.AuthModel.extend({
     urlRoot: function () {
-         return app.restEndpoint + "/oauth/client";
+         return app.config.restEndpoint + "/oauth/client";
      },
      defaults: {
          domain: '',
@@ -13,7 +13,7 @@ app.Models.OAuthClient = Backbone.AuthModel.extend({
 
 app.Models.OAuthClientsCollection = Backbone.AuthCollection.extend({
     url: function () {
-         return app.restEndpoint + "/oauth/client";
+         return app.config.restEndpoint + "/oauth/client";
     },
     model: app.Models.OAuthClient,
 });

--- a/scripts/models/OAuthConfig.js
+++ b/scripts/models/OAuthConfig.js
@@ -1,11 +1,11 @@
 app.Models.OAuthConfig = Backbone.Model.extend({
     url: function() {
-        return app.restEndpoint + '/info/config/auth';
+        return app.config.restEndpoint + '/info/config/auth';
     },
     initialize: function () {
         this.fetch({
             success: function(resp) {
-                app.oauthConfig = resp;
+                app.config.oauthConfig = resp;
             },
             async: false
         });

--- a/scripts/models/User.js
+++ b/scripts/models/User.js
@@ -1,6 +1,6 @@
 ﻿app.Models.User = Backbone.AuthModel.extend({
-    urlRoot: function () { return app.restEndpoint + "/user"; },
-    urlCurrent: function () { return app.restEndpoint + "/user/current"; },
+    urlRoot: function () { return app.config.restEndpoint + "/user"; },
+    urlCurrent: function () { return app.config.restEndpoint + "/user/current"; },
     error: function(e) {console.log('User error %o', e)},
     defaults: { login: "", status: app.Enums.UserStatus.Active, role: app.Enums.UserRole.Administrator, networks: [],
         googleLogin: "", facebookLogin: "", githubLogin: ""},
@@ -56,7 +56,7 @@
 });
 
 app.Models.UsersCollection = Backbone.AuthCollection.extend({
-    url: function () { return app.restEndpoint + "/user"; },
+    url: function () { return app.config.restEndpoint + "/user"; },
     model: app.Models.User,
     comparator: function (user) {
         var name = user.get("login");

--- a/scripts/models/UserInNetwork.js
+++ b/scripts/models/UserInNetwork.js
@@ -1,6 +1,6 @@
 ﻿app.Models.UserInNetwork = Backbone.AuthModel.extend({
     url: function () {
-        return app.restEndpoint + '/user/' + this.get("UserId") + "/network/" + this.get("NetworkId");
+        return app.config.restEndpoint + '/user/' + this.get("UserId") + "/network/" + this.get("NetworkId");
     },
     isNew: function () {
         return (_.isUndefined(this.attributes.network) || _.isUndefined(this.attributes.network.id));

--- a/scripts/views/Login.js
+++ b/scripts/views/Login.js
@@ -32,20 +32,20 @@ app.Views.Login = Backbone.Marionette.ItemView.extend({
             var identityProviderState = "provider=";
             var loginUrl = "&url=" + location.origin + location.pathname;
 
-            if (app.googleConfig) {
-                context.$el.find('#googleClientId')[0].value = app.googleConfig.clientId;
+            if (app.config.googleConfig) {
+                context.$el.find('#googleClientId')[0].value = app.config.googleConfig.clientId;
                 context.$el.find('#googleStateId')[0].value = identityProviderState + "google" + loginUrl;
                 context.$el.find(".google-identity-login").removeClass('ui-helper-hidden');
             }
 
-            if (app.facebookConfig) {
-                context.$el.find('#facebookClientId')[0].value = app.facebookConfig.clientId;
+            if (app.config.facebookConfig) {
+                context.$el.find('#facebookClientId')[0].value = app.config.facebookConfig.clientId;
                 context.$el.find('#facebookStateId')[0].value = identityProviderState + "facebook" + loginUrl;
                 context.$el.find(".facebook-identity-login").removeClass('ui-helper-hidden');
             }
 
-            if (app.githubConfig) {
-                context.$el.find('#githubClientId')[0].value = app.githubConfig.clientId;
+            if (app.config.githubConfig) {
+                context.$el.find('#githubClientId')[0].value = app.config.githubConfig.clientId;
                 context.$el.find('#githubStateId')[0].value = identityProviderState + "github" + loginUrl;
                 context.$el.find(".github-identity-login").removeClass('ui-helper-hidden');
             }

--- a/scripts/views/Notifications.js
+++ b/scripts/views/Notifications.js
@@ -125,7 +125,7 @@ app.Views.Notifications = Backbone.Marionette.CompositeView.extend({
             that.timeFiltersView.$el.hide();
         });
 
-        if (this.collection.length >= app.getConfig('deviceNotificationsNum')) {
+        if (this.collection.length >= app.config.deviceNotificationsNum) {
             that.$el.find(".max-rows-number-reached").show();
         }
         else {

--- a/scripts/views/Notifications.js
+++ b/scripts/views/Notifications.js
@@ -125,7 +125,7 @@ app.Views.Notifications = Backbone.Marionette.CompositeView.extend({
             that.timeFiltersView.$el.hide();
         });
 
-        if (this.collection.length >= 100) {
+        if (this.collection.length >= app.getConfig('deviceNotificationsNum')) {
             that.$el.find(".max-rows-number-reached").show();
         }
         else {

--- a/scripts/views/UserCreateEdit.js
+++ b/scripts/views/UserCreateEdit.js
@@ -84,13 +84,13 @@ app.Views.UserCreateEdit = Backbone.Marionette.ItemView.extend({
     },
 
     onRender: function() {
-        if (app.googleConfig) {
+        if (app.config.googleConfig) {
             this.$el.find(".google-identity-login").removeClass('ui-helper-hidden');
         }
-        if (app.facebookConfig) {
+        if (app.config.facebookConfig) {
             this.$el.find(".facebook-identity-login").removeClass('ui-helper-hidden');
         }
-        if (app.githubConfig) {
+        if (app.config.githubConfig) {
             this.$el.find(".github-identity-login").removeClass('ui-helper-hidden');
         }
     }


### PR DESCRIPTION
When new notification items arrive via polling channel the model adds new items and then the small check is appended that removes old records one by one until requested limit of visible notifications (100) not reached.
Misc:
Introduced an app.defaultConfig object and app.getConfig() method to get config properties. Default number of notifications per page is set to be 100.
Other parts of the code that were using this magic number now query app.getConfig('deviceNotificationsNum') for the value.
The default value can be altered by specifying new value in app.config object