### PR TITLE
[Docker] Hook script must fail if docker build fails

### DIFF
--- a/Docker/hooks/build
+++ b/Docker/hooks/build
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 echo "=== BUILD hook start ==="
 printenv


### PR DESCRIPTION
Without this we will get false successful build even if 'docker build' fails.